### PR TITLE
Wdp250801-7

### DIFF
--- a/src/components/features/ProductSearch/ProductSearch.js
+++ b/src/components/features/ProductSearch/ProductSearch.js
@@ -10,8 +10,15 @@ const ProductSearch = () => (
   <form action='' className={styles.root}>
     <div className={styles.category}>
       <FontAwesomeIcon className={styles.icon} icon={faListUl} />
-      <select name='' id=''>
+      <select
+        name=''
+        id=''
+        onChange={e => {
+          e.target.blur();
+        }}
+      >
         <option value=''>Select a category</option>
+        <option value='placeholder'>placeholder</option>
       </select>
       <FontAwesomeIcon className={styles.icon} icon={faCaretDown} />
     </div>

--- a/src/components/features/ProductSearch/ProductSearch.module.scss
+++ b/src/components/features/ProductSearch/ProductSearch.module.scss
@@ -32,6 +32,12 @@
       padding: 5px 30px 5px 35px;
       position: relative;
       z-index: 1;
+      font-size: 14px;
+
+      &:hover{
+        cursor: pointer;
+        color: $primary;
+      }
     }
   }
 


### PR DESCRIPTION
# Polski
## Opis problemu:
1. Select miał zły rozmiar czcionki,
2. Po wybraniu kategori został outline,
3. Brak hoverów,
## Moje rozwiązanie:
1. Ustawienie rozmiaru czcionki na `font-size: 14px` zgodnie z *Home.psd*
2. Dodałem do `select` funkcję `blur()` w `onChange()`. Funkcja ta usuwa `focus` z elementu gdy zmieni się `value` `select`. 
Funkcja ta nie działa z jedną opcją i na potrzeby testów dodałem dodatkowy `<option>` jako placeholder obecnie zostawiony na potrzeby code reiview.
3. Dodałem podstawowy `:hover` do `select` z powodu braku informacji w *Home.psd* obecnie zmienia tylko color czcionki na `$primary` oraz rodzaj kursora na *pointer*.
# English
## Problem description:
1. Select had the wrong font size,
2. After selecting a category, an outline was displayed,
3. No hover controls,
## My solution:
1. Set the font size to `font-size: 14px` according to *Home.psd*
2. I added the `blur()` function in `onChange()` to `select`. This function removes the `focus` from the element when the `select` value changes.This function doesn't work with one option, and for testing purposes, I added an additional `<option>` as a placeholder, currently left for the code reiview.
3. I added the basic `:hover` to `select` due to a lack of information in *Home.psd*. Currently, it only changes the font color to `$primary` and the cursor type to *pointer*.