### PR TITLE
Wdp250801 20

### DIFF
--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -38,7 +38,6 @@ class NewFurniture extends React.Component {
   };
 
   leftAction(pagesCount) {
-    //console.log('<- left');
     const newPage = this.state.activePage + 1;
     if (newPage < 0) {
       return;
@@ -50,7 +49,6 @@ class NewFurniture extends React.Component {
   }
 
   rightAction(pagesCount) {
-    //console.log('right ->');
     const newPage = this.state.activePage - 1;
     if (newPage < 0) {
       return;
@@ -82,16 +80,14 @@ class NewFurniture extends React.Component {
       );
     }
 
-    //console.log('viewport', this.state.viewport);
-
-    let colSize =
-      viewport.mode === 'desktop'
-        ? 'col-3'
-        : viewport.mode === 'tablet'
-        ? 'col-4'
-        : viewport.mode === 'mobile'
-        ? 'col-sm-6 col-12'
-        : 'col-12';
+    let colSize = 'col-12';
+    if (viewport.mode === 'desktop') {
+      colSize = 'col-3';
+    } else if (viewport.mode === 'tablet') {
+      colSize = 'col-4';
+    } else if (viewport.mode === 'mobile') {
+      colSize = 'col-sm-6 col-12';
+    }
 
     return (
       <div className={styles.root}>

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -62,7 +62,7 @@ class NewFurniture extends React.Component {
   }
 
   render() {
-    const { categories, products } = this.props;
+    const { categories, products, viewport } = this.props;
     const { activeCategory, activePage, counter } = this.state;
 
     const categoryProducts = products.filter(item => item.category === activeCategory);
@@ -81,6 +81,17 @@ class NewFurniture extends React.Component {
         </li>
       );
     }
+
+    //console.log('viewport', this.state.viewport);
+
+    let colSize =
+      viewport.mode === 'desktop'
+        ? 'col-3'
+        : viewport.mode === 'tablet'
+        ? 'col-4'
+        : viewport.mode === 'mobile'
+        ? 'col-sm-6 col-12'
+        : 'col-12';
 
     return (
       <div className={styles.root}>
@@ -117,7 +128,7 @@ class NewFurniture extends React.Component {
               {categoryProducts
                 .slice(activePage * 8, (activePage + 1) * 8)
                 .map(item => (
-                  <div key={item.id} className='col-12 col-sm-6 col-md-4 col-lg-3'>
+                  <div key={item.id} className={colSize}>
                     <ProductBox
                       {...item}
                       handleCompare={() => this.handleCompare(item)}
@@ -178,11 +189,16 @@ NewFurniture.propTypes = {
       newFurniture: PropTypes.bool,
     })
   ),
+  viewport: PropTypes.shape({
+    width: PropTypes.number,
+    mode: PropTypes.string,
+  }),
 };
 
 NewFurniture.defaultProps = {
   categories: [],
   products: [],
+  viewport: { width: 1024, mode: 'desktop' },
 };
 
 export default NewFurniture;

--- a/src/components/features/NewFurniture/NewFurnitureContainer.js
+++ b/src/components/features/NewFurniture/NewFurnitureContainer.js
@@ -4,10 +4,12 @@ import NewFurniture from './NewFurniture';
 
 import { getAll } from '../../../redux/categoriesRedux.js';
 import { getNew } from '../../../redux/productsRedux.js';
+import { getViewport } from '../../../redux/viewportRedux.js';
 
 const mapStateToProps = state => ({
   categories: getAll(state),
   products: getNew(state),
+  viewport: getViewport(state),
 });
 
 export default connect(mapStateToProps)(NewFurniture);

--- a/src/components/layout/MainLayout/MainLayout.js
+++ b/src/components/layout/MainLayout/MainLayout.js
@@ -1,16 +1,34 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import Header from '../Header/Header';
 import Footer from '../Footer/Footer';
 
-const MainLayout = ({ children }) => (
-  <div>
-    <Header />
-    {children}
-    <Footer />
-  </div>
-);
+import { useDispatch } from 'react-redux';
+import { setViewportMode } from '../../../redux/viewportRedux';
+
+const MainLayout = ({ children }) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const handleResize = () => {
+      const width = window.innerWidth;
+      const mode = width < 768 ? 'mobile' : width < 1024 ? 'tablet' : 'desktop';
+      //console.log(`Viewport mode changed to: ${mode}`);
+      dispatch(setViewportMode({ width, mode }));
+    };
+    handleResize(); // początkwe wywołanie, aby ustawić początkowy stan
+    window.addEventListener('resize', handleResize); // dodanie nasluchiwnia na zmianę rozmiaru okna
+  }, [dispatch]);
+
+  return (
+    <div>
+      <Header />
+      {children}
+      <Footer />
+    </div>
+  );
+};
 
 MainLayout.propTypes = {
   children: PropTypes.node,

--- a/src/components/layout/MainLayout/MainLayout.js
+++ b/src/components/layout/MainLayout/MainLayout.js
@@ -14,7 +14,6 @@ const MainLayout = ({ children }) => {
     const handleResize = () => {
       const width = window.innerWidth;
       const mode = width < 768 ? 'mobile' : width < 1024 ? 'tablet' : 'desktop';
-      //console.log(`Viewport mode changed to: ${mode}`);
       dispatch(setViewportMode({ width, mode }));
     };
     handleResize(); // początkwe wywołanie, aby ustawić początkowy stan

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -283,6 +283,10 @@ const initialState = {
   cart: {
     products: [],
   },
+  viewport: {
+    width: 1024,
+    mode: 'desktop',
+  },
 };
 
 export default initialState;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -4,12 +4,14 @@ import initialState from './initialState';
 import cartReducer from './cartRedux';
 import categoriesReducer from './categoriesRedux';
 import productsReducer from './productsRedux';
+import viewportReducer from './viewportRedux';
 
 // define reducers
 const reducers = {
   cart: cartReducer,
   categories: categoriesReducer,
   products: productsReducer,
+  viewport: viewportReducer,
 };
 
 // add blank reducers for initial state properties without reducers

--- a/src/redux/viewportRedux.js
+++ b/src/redux/viewportRedux.js
@@ -1,0 +1,20 @@
+/* selectors */
+export const getViewport = ({ viewport }) => viewport;
+
+/* actions */
+const createActionName = name => `app/viewport/${name}`;
+const SET_VIEWPORT_MODE = createActionName('SET_VIEWPORT_MODE');
+export const setViewportMode = ({ width, mode }) => ({
+  type: SET_VIEWPORT_MODE,
+  payload: { width, mode },
+});
+
+/* reducer */
+export default function reducer(statePart = { mode: 'desktop' }, action = {}) {
+  switch (action.type) {
+    case SET_VIEWPORT_MODE:
+      return { ...statePart, width: action.payload.width, mode: action.payload.mode };
+    default:
+      return statePart;
+  }
+}


### PR DESCRIPTION
### OPIS PROBLEMU:
Aktualna szerokość ekranu ma decydować o tym w jakim trybie jest wyświetlana aplikacja: desktop, tablet lub mobile. Tryb ma być zapisywany w stanie aplikacji. Pierwsze wykorzystanie zapisanego trybu miało mieć miejsce w NewFurniture.js

##
### ROZWIĄZANIE:
- Zmodyfikowano MainLayout.js o funkcjonalność sprawdzania rozmiaru ekranu i zapisanie trybu do stanu aplikacji
- Stworzono reducer vieportRedux.js
- Zmodyfikowano NewFurnitureContainer.js o nowy props: viewport
- Zmodyfikowano NewFurniture.js tak aby wykorzystywał on tryb zapisany w stanie aplikacji do określenia rozmiaru kart productów